### PR TITLE
Fix #22 pass file object to onChange for FileInput

### DIFF
--- a/examples/js/components/FileInput.jsx
+++ b/examples/js/components/FileInput.jsx
@@ -3,8 +3,13 @@ import {Card, CardText, CardTitle, Paper} from 'material-ui'
 import {FileInput} from 'safe-framework'
 
 class Area extends Component {
-  onChange (value) {
-    window.alert(value)
+  onChange (file) {
+    let alertText = ''
+
+    for (let key in file) {
+      alertText += `${key}: ${file[key]}\n`
+    }
+    window.alert(alertText)
   }
 
   render () {

--- a/src/FileInput/FileInput.jsx
+++ b/src/FileInput/FileInput.jsx
@@ -16,9 +16,10 @@ export class FileInput extends Component {
 
   onChange ({target}) {
     const value = target.value
+    const file = target.files[0]
 
     this.updateText(value)
-    this.props.onChange(value)
+    this.props.onChange(file)
   }
 
   openFileBrowser () {


### PR DESCRIPTION
Needed for jeffshaver/safe-app#37. The onChange there (which will read the file to check for CSVness of the file and then try to guess the field types in the file) needs not just the filename but the actual file object. This change does that.
