### PR TITLE
Issue #41: Parsed data to generate the y series for charts.

### DIFF
--- a/examples/js/components/Column.jsx
+++ b/examples/js/components/Column.jsx
@@ -1,11 +1,11 @@
 import React, {Component} from 'react'
 import {Card, CardTitle, Paper} from 'material-ui'
 import {DefaultColumnChart} from 'safe-framework'
-import {columnDrilldown, columnSeries, tableColumns, tableData} from '../fixtures'
+import {columnSeriesFromData, tableColumns, tableData} from '../fixtures'
 
 const chartConfig = {
   legend: {
-    display: false
+    display: true
   },
   scales: {
     xAxes: [{}],
@@ -28,10 +28,9 @@ class Column extends Component {
             title='Column + Table'
           />
           <DefaultColumnChart
-            chartData={columnSeries}
+            chartData={columnSeriesFromData}
             chartOptions={chartConfig}
             columns={tableColumns}
-            drilldown={columnDrilldown}
             size={'col-xs-12 col-sm-12'}
             tableData={tableData}
             title={'Browser market shares. January, 2015 to May, 2015'}

--- a/examples/js/fixtures.js
+++ b/examples/js/fixtures.js
@@ -107,12 +107,8 @@ export const columnDrilldown = {
 export const columnSeries = {
   label: 'Brands',
   colorByPoint: true,
-  xAxis: [{
-    dataProperty: 'name'
-  }],
-  yAxis: [{
-    dataProperty: 'y'
-  }],
+  xAxis: ['name'],
+  yAxis: ['y'],
   data: [{
     name: 'Microsoft Internet Explorer',
     y: 56.33,
@@ -137,6 +133,59 @@ export const columnSeries = {
     name: 'Proprietary or Undetectable',
     y: 0.2,
     drilldown: null
+  }]
+}
+
+// Gettin Series Info From Data
+export const columnSeriesFromData = {
+  label: 'Internet Browser Use By Gender',
+  colorByPoint: true,
+  xAxis: ['name'],
+  ySeriesField: 'series',
+  data: [{
+    name: 'Microsoft Internet Explorer',
+    y: 56.33,
+    series: [
+      {name: 'male', value: 30.33},
+      {name: 'female', value: 26}
+    ]
+  }, {
+    name: 'Chrome',
+    y: 24.03,
+    series: {
+      male: 15,
+      female: 4.03,
+      someUnknown: 5
+    }
+  }, {
+    name: 'Firefox',
+    y: 10.38,
+    series: {
+      male: 3,
+      female: 7.38
+    }
+  }, {
+    name: 'Safari',
+    y: 4.77,
+    series: {
+      male: 2,
+      female: 1.77,
+      someUnknown: 1
+    }
+  }, {
+    name: 'Opera',
+    y: 0.91,
+    series: {
+      male: 0,
+      female: 0.91
+    }
+  }, {
+    name: 'Proprietary or Undetectable',
+    y: 0.2,
+    series: {
+      male: 0.1,
+      female: 0.1
+    }
   }]
 }
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "ag-grid": "^4.0.0",
     "ag-grid-react": "^4.0.0",
-    "chart.js": "^2.0.0",
+    "chart.js": "^2.1.0",
     "chroma-js": "^1.1.1",
     "color": "^0.11.1",
     "eslint-plugin-promise": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,13 @@
   "dependencies": {
     "ag-grid": "^4.1.5",
     "ag-grid-react": "^4.0.0",
-    "chart.js": "^2.0.0",
+    "chart.js": "^2.1.0",
     "chroma-js": "^1.1.1",
     "color": "^0.11.1",
     "flexboxgrid": "^6.3.0",
     "lodash.debounce": "^4.0.0",
-    "safe-framework-react-chartjs": "^2.0.0"
+    "safe-framework-react-chartjs": "^2.0.0",
+    "title-case": "^1.1.2"
   },
   "peerDependencies": {
     "material-ui": "^0.14.4",

--- a/src/AreaChart/AreaChart.jsx
+++ b/src/AreaChart/AreaChart.jsx
@@ -3,7 +3,7 @@ import Chart, {DefaultChart} from '../Chart'
 import {Line} from 'safe-framework-react-chartjs'
 
 @Chart
-class AreaChart extends Component {
+export default class AreaChart extends Component {
   static propTypes = {}
 
   render () {

--- a/src/BarChart/BarChart.jsx
+++ b/src/BarChart/BarChart.jsx
@@ -1,10 +1,16 @@
-import React, {Component} from 'react'
+import React, {Component, PropTypes} from 'react'
 import Chart, {DefaultChart} from '../Chart'
 import {Bar} from 'safe-framework-react-chartjs'
 
 @Chart
 export default class BarChart extends Component {
-  static propTypes = {}
+  static propTypes = {
+    backgroundColorAlpha: PropTypes.number
+  }
+  
+  static defaultProps = {
+    backgroundColorAlpha: 1
+  }
 
   render () {
     return (

--- a/src/ColumnChart/ColumnChart.jsx
+++ b/src/ColumnChart/ColumnChart.jsx
@@ -3,8 +3,12 @@ import Chart, {DefaultChart} from '../Chart'
 import {Bar} from 'safe-framework-react-chartjs'
 
 @Chart
-class ColumnChart extends Component {
+export default class ColumnChart extends Component {
   static propTypes = {}
+  
+  static defaultProps = {
+    backgroundColorAlpha: 1
+  }
 
   render () {
     return (

--- a/src/LineChart/LineChart.jsx
+++ b/src/LineChart/LineChart.jsx
@@ -3,7 +3,7 @@ import Chart, {DefaultChart} from '../Chart'
 import {Line} from 'safe-framework-react-chartjs'
 
 @Chart
-class LineChart extends Component {
+export default class LineChart extends Component {
   static propTypes = {
     data: PropTypes.object.isRequired
   }

--- a/src/PieChart/PieChart.jsx
+++ b/src/PieChart/PieChart.jsx
@@ -3,7 +3,7 @@ import Chart, {DefaultChart} from '../Chart'
 import {Pie} from 'safe-framework-react-chartjs'
 
 @Chart
-class PieChart extends Component {
+export default class PieChart extends Component {
   static propTypes = {
     colorPalette: PropTypes.func,
     colorScale: PropTypes.string,

--- a/src/ScatterPlot/ScatterPlot.jsx
+++ b/src/ScatterPlot/ScatterPlot.jsx
@@ -3,7 +3,7 @@ import Chart, {DefaultChart} from '../Chart'
 import {Scatter} from 'safe-framework-react-chartjs'
 
 @Chart
-class ScatterPlot extends Component {
+export default class ScatterPlot extends Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
     options: PropTypes.object


### PR DESCRIPTION
Added in the ability to just specify a String instead of the **dataProperty** property for the xAxis and yAxis properties.

Also added in the **ySeriesField** property. If specified, this field will find that property name in each of the data objects and parse the information to generate the y series datasets for a chart.

Will update the wiki page with this information.
