### PR TITLE
Reverting MarkerCluster back to using context. React-leaflet made fix…

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -59,7 +59,7 @@
     "radium": "^0.17.1",
     "react": "^15.2.0",
     "react-dom": "^15.2.0",
-    "react-leaflet": "0.11.6",
+    "react-leaflet": "^0.12.1",
     "react-redux": "^4.4.0",
     "react-router": "^2.4.1",
     "react-tap-event-plugin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "radium": "^0.17.1",
     "react": "^15.2.0",
     "react-dom": "^15.2.0",
-    "react-leaflet": "^0.11.0",
+    "react-leaflet": "^0.12.1",
     "react-tap-event-plugin": "^1.0.0"
   }
 }

--- a/src/Map/MarkerCluster.jsx
+++ b/src/Map/MarkerCluster.jsx
@@ -26,17 +26,6 @@ export class MarkerCluster extends MapLayer {
   }
   
   render () {
-    const {children = [], map} = this.props
-    
-    return (
-      <div style={{display: 'none'}}>
-        {children.map((child) => (
-          React.cloneElement(child, {
-            layerContainer: this.leafletElement,
-            map
-          })
-        ))}
-      </div>
-    )
+    return <div style={{display: 'none'}}>{this.props.children}</div>
   }
 }


### PR DESCRIPTION
…es in 0.12.1
